### PR TITLE
Add link to the fork to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Jupyterlab Extensions Walkthrough #
 
+**Development is now happening in https://github.com/jtpio/jupyterlab-extension-examples with the following roadmap**:
+
+- Update to JupyterLab 1.0
+- Update existing examples
+- Add more examples
+- Move the repo to https://github.com/jupyterlab when ready
+
 ## Other tutorials ##
 * http://JupyterLab.readthedocs.io/en/stable/developer/xkcd_extension_tutorial.html
 


### PR DESCRIPTION
This change adds a link to the fork where further development is now happening.

The idea is to redirect as many people as possible to help moving the project forward.

Many thanks again @MMesch for starting this!